### PR TITLE
Tweaks (support Mariadb)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   # Database server
   mysql:
-    image: mysql
+    image: mariadb
     environment:
       MYSQL_DATABASE: drupal
       MYSQL_ROOT_PASSWORD: drupal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     volumes:
       - ./drupal/core:/var/www/html/core
       - drupal_files:/var/www/html/sites/default/files
+    environment:
+      SIMPLETEST_DB: mysql://root:drupal@mysql/drupal
+      SIMPLETEST_BASE_URL: http://localhost
     links:
       - mysql:mysql
     working_dir: /var/www/html


### PR DESCRIPTION
Hi,

I had to switch to using the `mariadb` images instead of the `mysql` images. With the mysql image I ran into an "Authentication plugin 'caching_sha2_password' cannot be loaded" error.

Also to able to run some test cases you have to set the `SIMPLETEST_DB` and `SIMPLETEST_BASE_URL` environment variables. I think it makes sense to add them to the Docker Compose configuration for better out-of-the-box experience.